### PR TITLE
Warm up the camera: this significantly improves image quality

### DIFF
--- a/check_wifi.sh
+++ b/check_wifi.sh
@@ -19,7 +19,8 @@ echo $SAVED
 
 if [ "$SSID" != "$SAVED" ]; then
 	DATE=$(date +"%Y%m%d%H%M")
-	/usr/local/bin/imagesnap "${FILEPATH}photos/${DATE}-${SSID}.jpg"
+	# Warm up the camera: '-w 1.0'
+	/usr/local/bin/imagesnap -w 1.0 "${FILEPATH}photos/${DATE}-${SSID}.jpg"
 	echo "$SSID" > "$FILE"
 	sleep 5
 #	python "${FILEPATH}tumblr.py" $DATE $SSID


### PR DESCRIPTION
A quick, unscientific sample from my 2014 retina MacBook Pro:

With no warmup (i.e. just running `imagesnap`):

![snapshot](https://cloud.githubusercontent.com/assets/474/15869997/9073b2d2-2ca3-11e6-9dde-d81b91387864.jpg)

A 1.0 s warmup (`imagesnap -w 1.0`):

![snapshot-1 0](https://cloud.githubusercontent.com/assets/474/15870008/99b57efc-2ca3-11e6-8087-2aa0a7af7fa5.jpg)

(On my machine, the images get much better at 0.7 s or later, but 1.0 is a nice round number.)
